### PR TITLE
Updated plugin for Matomo 5.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Password Policy plugin for Matomo (aka Piwik).
 ## Installation
 Install it via Matomo Marketplace
 
-| Matomo version  | Plugin version |
-| ------------- | ------------- |
-| 3.x  | 1.x |
-| 4.x  | 2.x |
+| Matomo version | Plugin version |
+|----------------| ------------- |
+| 3.x            | 1.x |
+| 4.x            | 2.x |
+| 5.x            | 2.x |
 
 ## License
 See [LICENSE](LICENSE) file 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "PasswordPolicyEnforcer",
-  "version": "2.0.1",
-  "description": "Adds a possibility to enforce Password Policy.",
+  "version": "2.0.2",
+  "description": "Adds a possibility to enforce Password Policy test.",
   "theme": false,
   "keywords": [
     "password policy",
@@ -11,9 +11,10 @@
   "homepage": "https://github.com/simivar/matomo-password-policy-enforcer",
   "license": "MIT",
   "require": {
-    "piwik": ">=4.0.0-b1,<5.0.0-b1",
+    "matomo": ">=4.0.0-b1,<6.0.0-b1",
     "php": ">=7.2.5"
   },
+  "matomo": ">=4.0.0-b1,<6.0.0-b1",
   "support": {
     "issues": "https://github.com/simivar/matomo-password-policy-enforcer/issues",
     "source": "https://github.com/simivar/matomo-password-policy-enforcer",


### PR DESCRIPTION
Updated the plugins.json, the validation code works with Matomo 5.x.

https://github.com/simivar/matomo-password-policy-enforcer/issues/15

Thank you for your plugin.